### PR TITLE
Fix panic on rates not divisible by 20

### DIFF
--- a/src/af_replaygain.rs
+++ b/src/af_replaygain.rs
@@ -642,7 +642,7 @@ pub fn filter_frame(ctx: &mut ReplayGainContext, frame: &[f32]) {
     calc_stereo_peak(frame, &mut ctx.peak);
     yule_filter_stereo_samples(ctx, frame, &mut buf[..]);
     butter_filter_stereo_samples(ctx, &mut buf[..]);
-    let level = (100f64 * calc_stereo_rms(&mut buf[..])).floor() as usize;
+    let level = (100f64 * calc_stereo_rms(&buf[..])).floor() as usize;
 
     ctx.histogram[clip(level, 0, HISTOGRAM_SLOTS - 1)] += 1;
 //    return ff_filter_frame(outlink, in);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ impl ReplayGain {
         }
 
         for chunk in remainder.iter().flat_map(|x| x.chunks(frame_size)) {
-            if chunk.len() == self.frame_size() {
+            if chunk.len() == frame_size {
                 assert!(self.buf.is_empty());
                 filter_frame(&mut self.ctx, chunk);
             } else {
@@ -139,8 +139,10 @@ impl ReplayGain {
 
     /// Completes the analysis and returns the two replaygain values (gain, peak).
     pub fn finish(mut self) -> (f32, f32) {
-        // FIXME: handle the remaining data in self.buf
-        // not sure how ffmpeg deals with this
+        // pass in any remaining buffer after padding with zeros
+        self.buf.resize(self.frame_size(), 0.0);
+        filter_frame(&mut self.ctx, &self.buf[..]);
+        self.buf.clear();
 
         finish(&mut self.ctx)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl ReplayGain {
     /// Returns `None` if the sample rate is not supported.
     pub fn new(sample_rate: usize) -> Option<ReplayGain>{
         freq_to_info(sample_rate).map(|x| ReplayGain {
-            sample_rate: sample_rate,
+            sample_rate,
             ctx: init_context(&x),
             buf: Vec::new(),
         })
@@ -118,7 +118,7 @@ impl ReplayGain {
             self.buf.extend_from_slice(&frame[..input]);
             if can_fill {
                 assert!(self.buf.len() == frame_size);
-                filter_frame(&mut self.ctx, &mut self.buf[..]);
+                filter_frame(&mut self.ctx, &self.buf[..]);
                 self.buf.clear();
                 remainder = Some(&frame[input..]);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl ReplayGain {
     /// in **floats**. Note that because we expect stereo audio, this means that you
     /// need to divide this by 2 to get the number of *samples*.
     pub fn frame_size(&self) -> usize {
-        self.sample_rate / 10
+        self.sample_rate / 20 * 2
     }
 
     /// Processes a single audio frame.


### PR DESCRIPTION
Thanks for the library, I am finding it useful for most files.

Unfortunately there is a small bug as it fails on any files that have a sampling rate that is not divisible by 20, such as 22050. This is because the `frame_size` is `self.sample_rate / 10` (so 2205 for 22050) and each of the functions that `filter_frame` call assert that an even number of samples was passed in. Not only that, but because `process_frame` requires that the frames are in the "correct" size, there is no workaround.

This fix seemed like the simplest solution, make `frame_size` `self.sample_rate / 20 * 2` so it is always even.

I've also addressed a few minor clippy warnings.

Finally, I adjusted `finish` to send the remainder of the buffer into `filter_frame` by padding it with zeros to get to `frame_size` so that no samples are left behind.